### PR TITLE
fix: issue with omiting endpoint

### DIFF
--- a/config.go
+++ b/config.go
@@ -326,7 +326,8 @@ func ParsePeers(cfg *ini.File, peers *[]PeerConfig) error {
 			peer.PreSharedKey = value
 		}
 
-		if value, err := parseString(section, "Endpoint"); err == nil {
+		if sectionKey, err := section.GetKey("Endpoint"); err == nil {
+			value := sectionKey.String()
 			decoded, err = resolveIPPAndPort(strings.ToLower(value))
 			if err != nil {
 				return err


### PR DESCRIPTION
fixes #156

--------

Seems like this change broke the functionality: https://github.com/pufferffish/wireproxy/commit/cb1f39b3e5896f50a899a2bd1a2a91470eda247e#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L295-R329

Reverting from:
```
if value, err := parseString(section, "Endpoint"); err == nil {
```

To
```
if sectionKey, err := section.GetKey("Endpoint"); err == nil {
	value := sectionKey.String()
```

Fixed the issue.

I'm not well versed in the code nor Golang for that to be an issue to revert to the old code, but it seems to work fine. And all the following lines still use the same method "if sectionKey, err := section." and so on.